### PR TITLE
Change typo in example to forward slash

### DIFF
--- a/FritzFrog/README.md
+++ b/FritzFrog/README.md
@@ -12,7 +12,7 @@ This repository contains a list of IoCs and a detection tool for the [FritzFrog 
 ### Running the Script
 Open a Linux terminal and run
 ```
-.\detect_fritzfrog.sh
+./detect_fritzfrog.sh
 ```
 The script detects checks whether:
 1. a fileless process named _nginx / ifconfig / libexec / php-fpm_ is running


### PR DESCRIPTION
Noticed a trivial typo.

If someone followed the exact command they would get an error something like ```.detect_fritzfrog.sh: command not found```

Though without execute bit set they'll probably get a permission denied error