### PR TITLE
detect_fritzfrog.sh: Cleanup and POSIX

### DIFF
--- a/FritzFrog/detect_fritzfrog.sh
+++ b/FritzFrog/detect_fritzfrog.sh
@@ -1,28 +1,30 @@
-echo "FritzFrog Detection Script by Guardicore Labs"
-echo -e "=============================================\n"
+#!/usr/bin/env sh
+echo 'FritzFrog Detection Script by Guardicore Labs
+=============================================
+'
 
-proc_names=( "nginx" "ifconfig" "libexec" "php-fpm" )
+proc_names='nginx ifconfig libexec php-fpm'
 malicious_proc=false
 listening_port=false
 
-for pn in "${proc_names[@]}"
+for pn in $proc_names
 do
     exe_path=$(ls -l /proc/$(pidof $pn)/exe 2>/dev/null | grep deleted)
-    if [[ $exe_path ]]; then
+    if [ -n "$exe_path" ]; then
         malicious_proc=true
-        echo "[*] Fileless process" $pn "is running on the server."
+        echo "[*] Fileless process $pn is running on the server."
     fi
 done
 
-if [[ $(netstat -ano | grep LISTEN | grep 1234) ]]; then
+netstat -ano | grep LISTEN | grep -q 1234 && {
     listening_port=true
-    echo "[*] Listening on port 1234"
-fi
+    echo '[*] Listening on port 1234'
+}
 
 if $malicious_proc || $listening_port; then
     echo "[*] There is evidence of FritzFrog's malicious activity on this machine."
     exit 1
 else
-    echo "[*] The machine seems clean."
+    echo '[*] The machine seems clean.'
     exit 0
 fi


### PR DESCRIPTION
Add shebang.
Remove superfluous bashisms in order to make script POSIX and hence more
portable.
Single quotes where double quotes are not needed.
Use return code from grep instead of checking output empty string.
