### PR TITLE
detect_fritzfrog.sh: Match port 1234 and not 1234[anything]

### DIFF
--- a/FritzFrog/detect_fritzfrog.sh
+++ b/FritzFrog/detect_fritzfrog.sh
@@ -16,7 +16,7 @@ do
     fi
 done
 
-netstat -ano | grep LISTEN | grep -q 1234 && {
+netstat -ano | grep LISTEN | grep -wq 1234 && {
     listening_port=true
     echo '[*] Listening on port 1234'
 }


### PR DESCRIPTION
The current 'grep 1234' will match any port number that begins with
1234. That will generate false positives. Using the grep's -w paramter
makes sure we match 1234 only.

Signed-off-by: Joakim Roubert <joakim.roubert@gmail.com>