### PR TITLE
detect_fritzfrog.sh: Simplify if statement

### DIFF
--- a/FritzFrog/detect_fritzfrog.sh
+++ b/FritzFrog/detect_fritzfrog.sh
@@ -9,11 +9,10 @@ listening_port=false
 
 for pn in $proc_names
 do
-    exe_path=$(ls -l /proc/$(pidof $pn)/exe 2>/dev/null | grep deleted)
-    if [ -n "$exe_path" ]; then
+    ls -l /proc/$(pidof $pn)/exe 2>/dev/null | grep -q deleted && {
         malicious_proc=true
         echo "[*] Fileless process $pn is running on the server."
-    fi
+    }
 done
 
 netstat -ano | grep LISTEN | grep -q 1234 && {


### PR DESCRIPTION
No need to store exe_path since it is only used to verify the grep
outcome. This commit uses the grep status directly instead (just like
how it is done for the netstat command further down in the script).

Signed-off-by: Joakim Roubert <joakim.roubert@gmail.com>